### PR TITLE
allow settings by string content and options param refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 build/
 .project
 .cproject
+node-quickfix.xcworkspace
+node-quickfix.xcworkspace
+npm-debug.log
+.nadconfig.mk

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var quickfix = require(__dirname + '/build/Release/node_quickfix.node');
 
 var FIXInitiator = quickfix.FixInitiator;
 var FIXAcceptor = quickfix.FixAcceptor;
+
 exports.logonProvider = function(logon) {
 	return new quickfix.FixLoginProvider(logon);
 };
@@ -12,8 +13,8 @@ var events = require('events');
 inherits(FIXInitiator, events.EventEmitter);
 inherits(FIXAcceptor, events.EventEmitter);
 
-exports.initiator = function(propertiesFile, options) {
-	var initiator = new FIXInitiator(propertiesFile, {
+exports.initiator = function (options) {
+	var initiator = new FIXInitiator({
 		onCreate: function(sessionID) {
 			initiator.emit('onCreate', { sessionID: sessionID });
 		},
@@ -40,8 +41,8 @@ exports.initiator = function(propertiesFile, options) {
 	return initiator;
 };
 
-exports.acceptor = function(propertiesFile, options) {
-	var acceptor = new FIXAcceptor(propertiesFile, {
+exports.acceptor = function (options) {
+	var acceptor = new FIXAcceptor({
 		onCreate: function(sessionID) {
 			acceptor.emit('onCreate', { sessionID: sessionID });
 		},
@@ -69,7 +70,7 @@ exports.acceptor = function(propertiesFile, options) {
 };
 
 // extend prototype
-function inherits(target, source) {
+function inherits (target, source) {
   for (var k in source.prototype)
     target.prototype[k] = source.prototype[k];
 }

--- a/src/FixAcceptor.h
+++ b/src/FixAcceptor.h
@@ -29,7 +29,7 @@ class FixAcceptor : public FixConnection {
 		static NAN_METHOD(getSessions);
 		static NAN_METHOD(getSession);
 
-		FixAcceptor(const char* propertiesFile, std::string storeFactory);
+		FixAcceptor(FIX::SessionSettings settings, std::string storeFactory);
 
 	private:
 		~FixAcceptor();

--- a/src/FixConnection.cpp
+++ b/src/FixConnection.cpp
@@ -13,12 +13,18 @@
 #include "FixLogonEvent.h"
 #include "quickfix/SessionID.h"
 #include "quickfix/Message.h"
+#include "quickfix/Dictionary.h"
+#include "quickfix/SessionSettings.h"
+#include "quickfix/Settings.h"
 
 using namespace v8;
 using namespace node;
+using namespace FIX;
 
-FixConnection::FixConnection(const char* propertiesFile, std::string storeFactory): ObjectWrap()  {
-	mSettings = FIX::SessionSettings(propertiesFile);
+FixConnection::FixConnection(FIX::SessionSettings settings, std::string storeFactory): ObjectWrap()  {
+
+  mSettings = settings;
+
 	mFixApplication = new FixApplication(
 			&mAsyncFIXEvent, &mAsyncLogonEvent, &mCallbacks);
 

--- a/src/FixConnection.h
+++ b/src/FixConnection.h
@@ -41,7 +41,7 @@ using namespace node;
 
 class FixConnection : public node::ObjectWrap {
 public:
-	FixConnection(const char* propertiesFile, std::string storeFactory);
+	FixConnection(FIX::SessionSettings settings, std::string storeFactory);
 
 private:
 

--- a/src/FixInitiator.h
+++ b/src/FixInitiator.h
@@ -29,7 +29,7 @@ class FixInitiator : public FixConnection {
   static NAN_METHOD(getSessions);
   static NAN_METHOD(getSession);
 
-  FixInitiator(const char* propertiesFile, std::string storeFactory);
+  FixInitiator(FIX::SessionSettings settings, std::string storeFactory);
 
  private:
   ~FixInitiator();


### PR DESCRIPTION
refactoring to single options parameter. throwing nan errors if incorrect options provided. adding ability to provide settings string representing properties file contents, or provide prop file path - as before.
