### PR TITLE
adding refence counting for libuv

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-quickfix",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "scripts": {
     "preinstall": "npm install nan && node-gyp clean && node-gyp configure && node-gyp build",
     "preuninstall": "rm -rf build/*"

--- a/src/Dispatcher.h
+++ b/src/Dispatcher.h
@@ -39,6 +39,8 @@ class Dispatcher {
         NODE_QUICKFIX_MUTEX_UNLOCK(&dispatcher->mutex);
 
         for (unsigned int i = 0, size = events.size(); i < size; i++) {
+            uv_unref((uv_handle_t *)&dispatcher->watcher);
+
             fix_event_t* event = events[i];
 
             Local<String> eventName = NanNew<String>(event->eventName.c_str());
@@ -68,6 +70,7 @@ class Dispatcher {
 
     void dispatch(fix_event_t* event) {
         //std::cout << "dispatching onCreate event " << '\n';
+        uv_ref((uv_handle_t *)&watcher);
 
         NODE_QUICKFIX_MUTEX_LOCK(&mutex);
         data.push_back(event);


### PR DESCRIPTION
Enabling reference counting for the node event loop so it doesn't yield prematurely when there are more inbound messages on the dispatcher.  See uv_ref and uv_unref in http://nikhilm.github.io/uvbook/utilities.html.
