### PR TITLE
Node.js v4.2.2 LTS and v5.1.0 support

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,7 +3,7 @@
     {
       'target_name': 'node_quickfix',
       'product_extension': 'node',
-      'type': 'shared_library',
+      'type': 'loadable_module',
       'sources': [
         'src/Threading.h',
         'src/Dispatcher.h',
@@ -43,7 +43,7 @@
           '-L/usr/lib',
           '-L/usr/local/lib',
           '-lquickfix',
-          '-lpthread', 
+          '-lpthread',
           '-lxml2',
           '-lz'
         ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-quickfix",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "scripts": {
     "preinstall": "npm install nan && node-gyp clean && node-gyp configure && node-gyp build",
     "preuninstall": "rm -rf build/*"

--- a/src/FixAcceptor.h
+++ b/src/FixAcceptor.h
@@ -20,7 +20,7 @@ using namespace node;
 
 class FixAcceptor : public FixConnection {
 	public:
-		//static Persistent<Function> constructor;
+		//static Nan::Persistent<Function> constructor;
 		static void Initialize(Handle<Object> target);
 		static NAN_METHOD(New);
 		static NAN_METHOD(start);
@@ -37,7 +37,7 @@ class FixAcceptor : public FixConnection {
 	protected:
 		FIX::ThreadedSocketAcceptor* mAcceptor;
 		FixLoginProvider* mFixLoginProvider;
-		static void sendAsync(_NAN_METHOD_ARGS, FIX::Message* message);
+		static void sendAsync(const Nan::FunctionCallbackInfo<v8::Value>& info, FIX::Message* message);
 };
 
 #endif /* FIXACCEPTOR_H_ */

--- a/src/FixAcceptorStartWorker.cpp
+++ b/src/FixAcceptorStartWorker.cpp
@@ -31,11 +31,11 @@ void FixAcceptorStartWorker::Execute () {
 // this function will be run inside the main event loop
 // so it is safe to use V8 again
 void FixAcceptorStartWorker::HandleOKCallback () {
-	NanScope();
+	Nan::HandleScope scope;
 
 	if(!callback->IsEmpty()) {
 		Local<Value> argv[] = {
-			NanNull()
+			Nan::Null()
 		};
 
 		callback->Call(1, argv);

--- a/src/FixAcceptorStartWorker.h
+++ b/src/FixAcceptorStartWorker.h
@@ -10,11 +10,11 @@
 using namespace v8;
 using namespace node;
 
-class FixAcceptorStartWorker : public NanAsyncWorker
+class FixAcceptorStartWorker : public Nan::AsyncWorker
 {
 	public:
-		FixAcceptorStartWorker(NanCallback *callback, FIX::ThreadedSocketAcceptor* acceptor)
-			: NanAsyncWorker(callback), acceptor(acceptor) {}
+		FixAcceptorStartWorker(Nan::Callback *callback, FIX::ThreadedSocketAcceptor* acceptor)
+			: Nan::AsyncWorker(callback), acceptor(acceptor) {}
 		~FixAcceptorStartWorker() {}
 
 		void Execute();

--- a/src/FixAcceptorStopWorker.cpp
+++ b/src/FixAcceptorStopWorker.cpp
@@ -31,11 +31,11 @@ void FixAcceptorStopWorker::Execute () {
 // this function will be run inside the main event loop
 // so it is safe to use V8 again
 void FixAcceptorStopWorker::HandleOKCallback () {
-	NanScope();
+	Nan::HandleScope scope;
 
 	if(!callback->IsEmpty()) {
 		Local<Value> argv[] = {
-			NanNull()
+			Nan::Null()
 		};
 
 		callback->Call(1, argv);

--- a/src/FixAcceptorStopWorker.h
+++ b/src/FixAcceptorStopWorker.h
@@ -10,11 +10,11 @@
 using namespace v8;
 using namespace node;
 
-class FixAcceptorStopWorker : public NanAsyncWorker
+class FixAcceptorStopWorker : public Nan::AsyncWorker
 {
 	public:
-		FixAcceptorStopWorker(NanCallback *callback, FIX::ThreadedSocketAcceptor* acceptor)
-			: NanAsyncWorker(callback), acceptor(acceptor) {}
+		FixAcceptorStopWorker(Nan::Callback *callback, FIX::ThreadedSocketAcceptor* acceptor)
+			: Nan::AsyncWorker(callback), acceptor(acceptor) {}
 		~FixAcceptorStopWorker() {}
 
 		void Execute();

--- a/src/FixApplication.cpp
+++ b/src/FixApplication.cpp
@@ -14,7 +14,7 @@ using namespace v8;
 
 FixApplication::FixApplication() {}
 
-FixApplication::FixApplication(v8::Persistent<v8::Object>* callbacks, std::unordered_set<std::string>* callbackRegistry)
+FixApplication::FixApplication(Nan::Persistent<v8::Object>* callbacks, std::unordered_set<std::string>* callbackRegistry)
 {
 	mCallbacks = callbacks;
 	mCallbackRegistry = callbackRegistry;
@@ -131,11 +131,10 @@ void FixApplication::setCredentials(fix_credentials* credentials) {
 	mCredentials = credentials;
 }
 
-void FixApplication::setCallbacks(v8::Persistent<v8::Object>* callbacks) {
+void FixApplication::setCallbacks(Nan::Persistent<v8::Object>* callbacks) {
 	mCallbacks = callbacks;
 }
 
 void FixApplication::setCallbackRegistry(std::unordered_set<std::string>* callbackRegistry) {
 	mCallbackRegistry = callbackRegistry;
 }
-

--- a/src/FixApplication.h
+++ b/src/FixApplication.h
@@ -17,15 +17,15 @@ class FixApplication : public FIX::Application
 {
 	public:
 		FixApplication();
-		FixApplication(v8::Persistent<v8::Object>* callbacks, std::unordered_set<std::string>* callbackRegistry);
+		FixApplication(Nan::Persistent<v8::Object>* callbacks, std::unordered_set<std::string>* callbackRegistry);
 		~FixApplication();
 		void setLogonProvider(FixLoginProvider* logonProvider);
 		void setCredentials(fix_credentials* credentials);
-		void setCallbacks(v8::Persistent<v8::Object>* callbacks);
+		void setCallbacks(Nan::Persistent<v8::Object>* callbacks);
 		void setCallbackRegistry(std::unordered_set<std::string>* callbackRegistry);
 
 	protected:
-		v8::Persistent<v8::Object>* mCallbacks;
+		Nan::Persistent<v8::Object>* mCallbacks;
 		std::unordered_set<std::string>* mCallbackRegistry;
 		fix_credentials* mCredentials = NULL;
 		FixLoginProvider* mLoginProvider = NULL;
@@ -33,7 +33,7 @@ class FixApplication : public FIX::Application
 		virtual void onCreate( const FIX::SessionID& sessionID );
 		virtual void onLogon( const FIX::SessionID& sessionID );
 		virtual void onLogout( const FIX::SessionID& sessionID );
-		
+
 		virtual void toAdmin( FIX::Message& message, const FIX::SessionID& sessionID);
 		virtual void fromAdmin( const FIX::Message& message, const FIX::SessionID& sessionID )
 		throw( FIX::FieldNotFound, FIX::IncorrectDataFormat, FIX::IncorrectTagValue, FIX::RejectLogon );

--- a/src/FixConnection.cpp
+++ b/src/FixConnection.cpp
@@ -20,7 +20,7 @@ using namespace v8;
 using namespace node;
 using namespace FIX;
 
-FixConnection::FixConnection(FIX::SessionSettings settings, std::string storeFactory): ObjectWrap()  {
+FixConnection::FixConnection(FIX::SessionSettings settings, std::string storeFactory): Nan::ObjectWrap()  {
 
   mSettings = settings;
 
@@ -30,7 +30,7 @@ FixConnection::FixConnection(FIX::SessionSettings settings, std::string storeFac
 
 }
 
-FixConnection::FixConnection(FixApplication* application, FIX::SessionSettings settings, std::string storeFactory): ObjectWrap()  {
+FixConnection::FixConnection(FixApplication* application, FIX::SessionSettings settings, std::string storeFactory): Nan::ObjectWrap()  {
 
   mSettings = settings;
 

--- a/src/FixConnection.h
+++ b/src/FixConnection.h
@@ -39,7 +39,7 @@
 using namespace v8;
 using namespace node;
 
-class FixConnection : public node::ObjectWrap {
+class FixConnection : public Nan::ObjectWrap {
 public:
 	FixConnection(FIX::SessionSettings settings, std::string storeFactory);
 	FixConnection(FixApplication* application, FIX::SessionSettings settings, std::string storeFactory);
@@ -55,7 +55,7 @@ protected:
 	FIX::LogFactory* mLogFactory;
 
 	FIX::SessionSettings mSettings;
-	v8::Persistent<v8::Object> mCallbacks;
+	Nan::Persistent<v8::Object> mCallbacks;
 	std::unordered_set<std::string> mCallbackRegistry;
 };
 

--- a/src/FixEvent.h
+++ b/src/FixEvent.h
@@ -19,10 +19,10 @@ using namespace v8;
 
 typedef struct fix_event_t {
 	std::string eventName;
-	v8::Persistent<v8::Object>* callbacks;
+	Nan::Persistent<v8::Object>* callbacks;
 	const FIX::SessionID* sessionId;
 	const FIX::Message* message = NULL;
-	NanCallback* logon = NULL;
+	Nan::Callback* logon = NULL;
 	FixLoginResponse* logonResponse;
 } fix_event_t;
 

--- a/src/FixInitiator.h
+++ b/src/FixInitiator.h
@@ -19,7 +19,7 @@ using namespace node;
 
 class FixInitiator : public FixConnection {
  public:
-  //virtual static Persistent<Function> constructor;
+  //virtual static Nan::Persistent<Function> constructor;
   static void Initialize(Handle<Object> target);
   static NAN_METHOD(New);
   static NAN_METHOD(start);
@@ -35,7 +35,7 @@ class FixInitiator : public FixConnection {
  private:
   ~FixInitiator();
   FIX::SocketInitiator* mInitiator;
-  static void sendAsync(_NAN_METHOD_ARGS, FIX::Message* message);
+  static void sendAsync(const Nan::FunctionCallbackInfo<v8::Value>& info, FIX::Message* message);
 };
 
 #endif

--- a/src/FixInitiatorStartWorker.cpp
+++ b/src/FixInitiatorStartWorker.cpp
@@ -31,11 +31,11 @@ void FixInitiatorStartWorker::Execute () {
 // this function will be run inside the main event loop
 // so it is safe to use V8 again
 void FixInitiatorStartWorker::HandleOKCallback () {
-	NanScope();
+	Nan::HandleScope scope;
 
 	if(!callback->IsEmpty()) {
 		Local<Value> argv[] = {
-			NanNull()
+			Nan::Null()
 		};
 
 		callback->Call(1, argv);

--- a/src/FixInitiatorStartWorker.h
+++ b/src/FixInitiatorStartWorker.h
@@ -10,11 +10,11 @@
 using namespace v8;
 using namespace node;
 
-class FixInitiatorStartWorker : public NanAsyncWorker
+class FixInitiatorStartWorker : public Nan::AsyncWorker
 {
 	public:
-		FixInitiatorStartWorker(NanCallback *callback, FIX::SocketInitiator* initiator)
-			: NanAsyncWorker(callback), initiator(initiator) {}
+		FixInitiatorStartWorker(Nan::Callback *callback, FIX::SocketInitiator* initiator)
+			: Nan::AsyncWorker(callback), initiator(initiator) {}
 		~FixInitiatorStartWorker() {}
 
 		void Execute();

--- a/src/FixInitiatorStopWorker.cpp
+++ b/src/FixInitiatorStopWorker.cpp
@@ -31,11 +31,11 @@ void FixInitiatorStopWorker::Execute () {
 // this function will be run inside the main event loop
 // so it is safe to use V8 again
 void FixInitiatorStopWorker::HandleOKCallback () {
-	NanScope();
+	Nan::HandleScope scope;
 
 	if(!callback->IsEmpty()) {
 		Local<Value> argv[] = {
-			NanNull()
+			Nan::Null()
 		};
 
 		callback->Call(1, argv);

--- a/src/FixInitiatorStopWorker.h
+++ b/src/FixInitiatorStopWorker.h
@@ -10,11 +10,11 @@
 using namespace v8;
 using namespace node;
 
-class FixInitiatorStopWorker : public NanAsyncWorker
+class FixInitiatorStopWorker : public Nan::AsyncWorker
 {
 	public:
-		FixInitiatorStopWorker(NanCallback *callback, FIX::SocketInitiator* initiator)
-			: NanAsyncWorker(callback), initiator(initiator) {}
+		FixInitiatorStopWorker(Nan::Callback *callback, FIX::SocketInitiator* initiator)
+			: Nan::AsyncWorker(callback), initiator(initiator) {}
 		~FixInitiatorStopWorker() {}
 
 		void Execute();

--- a/src/FixLoginProvider.cpp
+++ b/src/FixLoginProvider.cpp
@@ -10,7 +10,7 @@ using namespace v8;
 using namespace node;
 using namespace std;
 
-FixLoginProvider::FixLoginProvider() : ObjectWrap() {
+FixLoginProvider::FixLoginProvider() : Nan::ObjectWrap() {
 
 }
 
@@ -18,30 +18,30 @@ FixLoginProvider::~FixLoginProvider() {
 }
 
 void FixLoginProvider::Initialize(Handle<Object> target) {
-  NanScope();
+  Nan::HandleScope scope;
 
-  Local<FunctionTemplate> ctor = NanNew<FunctionTemplate>(FixLoginProvider::New);
+  Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(FixLoginProvider::New);
 
   // TODO:: Figure out what the compile error is with this
-  // NanAssignPersistent(constructor, ctor);
+  // constructor.Reset(ctor);
 
   ctor->InstanceTemplate()->SetInternalFieldCount(1);
-  ctor->SetClassName(NanNew("FixLoginProvider"));
+  ctor->SetClassName(Nan::New("FixLoginProvider").ToLocalChecked());
 
-  target->Set(NanNew("FixLoginProvider"), ctor->GetFunction());
+  target->Set(Nan::New("FixLoginProvider").ToLocalChecked(), ctor->GetFunction());
 }
 
 NAN_METHOD(FixLoginProvider::New) {
-	NanScope();
+	Nan::HandleScope scope;
 
 	FixLoginProvider *loginProvider = new FixLoginProvider();
 
-	loginProvider->Wrap(args.This());
-	loginProvider->logon = new NanCallback(args[0].As<Function>());
+	loginProvider->Wrap(info.This());
+	loginProvider->logon = new Nan::Callback(info[0].As<Function>());
 
-	NanReturnValue(args.This());
+	info.GetReturnValue().Set(info.This());
 }
 
-NanCallback* FixLoginProvider::getLogon() {
+Nan::Callback* FixLoginProvider::getLogon() {
 	return logon;
 }

--- a/src/FixLoginProvider.h
+++ b/src/FixLoginProvider.h
@@ -12,16 +12,16 @@
 #include <node.h>
 #include <nan.h>
 
-class FixLoginProvider : public node::ObjectWrap {
+class FixLoginProvider : public Nan::ObjectWrap {
 public:
 	FixLoginProvider();
 	static void Initialize(v8::Handle<v8::Object> target);
 	static NAN_METHOD(New);
-	NanCallback* getLogon();
+	Nan::Callback* getLogon();
 
 private:
 	virtual ~FixLoginProvider();
-	NanCallback* logon;
+	Nan::Callback* logon;
 };
 
 #endif /* FIXLOGINPROVIDER_H_ */

--- a/src/FixLoginResponse.cpp
+++ b/src/FixLoginResponse.cpp
@@ -11,7 +11,7 @@ using namespace v8;
 using namespace node;
 using namespace std;
 
-FixLoginResponse::FixLoginResponse() : ObjectWrap(){
+FixLoginResponse::FixLoginResponse() : Nan::ObjectWrap(){
 
 }
 
@@ -19,31 +19,31 @@ FixLoginResponse::~FixLoginResponse() {
 }
 
 void FixLoginResponse::Initialize(Handle<Object> target) {
-  NanScope();
+  Nan::HandleScope scope;
 
-  Local<FunctionTemplate> ctor = NanNew<FunctionTemplate>(FixLoginResponse::New);
+  Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(FixLoginResponse::New);
 
   ctor->InstanceTemplate()->SetInternalFieldCount(1);
-  ctor->SetClassName(NanNew("FixLoginResponse"));
+  ctor->SetClassName(Nan::New("FixLoginResponse").ToLocalChecked());
 
-  NODE_SET_PROTOTYPE_METHOD(ctor, "done", done);
+  Nan::SetPrototypeMethod(ctor, "done", done);
 
-  target->Set(NanNew("FixLoginResponse"), ctor->GetFunction());
+  target->Set(Nan::New("FixLoginResponse").ToLocalChecked(), ctor->GetFunction());
 }
 
 Handle<Object> FixLoginResponse::wrapFixLoginResponse(FixLoginResponse* fixLoginResponse) {
 
-	Local<FunctionTemplate> ctor = NanNew<FunctionTemplate>();
+	Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>();
 
 	ctor->InstanceTemplate()->SetInternalFieldCount(1);
-	ctor->SetClassName(NanNew("FixLoginResponse"));
+	ctor->SetClassName(Nan::New("FixLoginResponse").ToLocalChecked());
 
 	Local<ObjectTemplate> proto = ctor->PrototypeTemplate();
 
-	NODE_SET_PROTOTYPE_METHOD(ctor, "done", done);
+	Nan::SetPrototypeMethod(ctor, "done", done);
 
 	Handle<Object> obj = ctor->InstanceTemplate()->NewInstance();
-	//obj->SetInternalField(0, NanNew<External>(fixLoginResponse));
+	//obj->SetInternalField(0, Nan::New<External>(fixLoginResponse));
 
 	fixLoginResponse->Wrap(obj);
 	fixLoginResponse->Ref();
@@ -52,26 +52,26 @@ Handle<Object> FixLoginResponse::wrapFixLoginResponse(FixLoginResponse* fixLogin
 }
 
 NAN_METHOD(FixLoginResponse::New) {
-	NanScope();
+	Nan::HandleScope scope;
 
 	FixLoginResponse *loginResponse = new FixLoginResponse();
 
-	loginResponse->Wrap(args.This());
+	loginResponse->Wrap(info.This());
 
-	NanReturnValue(args.This());
+	info.GetReturnValue().Set(info.This());
 }
 
 NAN_METHOD(FixLoginResponse::done) {
-	NanScope();
+	Nan::HandleScope scope;
 
-	FixLoginResponse* instance = ObjectWrap::Unwrap<FixLoginResponse>(args.This());
+	FixLoginResponse* instance = Nan::ObjectWrap::Unwrap<FixLoginResponse>(info.This());
 
-	bool success = args[0]->ToBoolean()->BooleanValue();
+	bool success = info[0]->ToBoolean()->BooleanValue();
 
 	instance->setIsFinished(true);
 	instance->setIsLoggedOn(success);
 
-	NanReturnUndefined();
+	return;
 }
 
 bool FixLoginResponse::getIsFinished() {

--- a/src/FixLoginResponse.h
+++ b/src/FixLoginResponse.h
@@ -13,7 +13,7 @@
 using namespace v8;
 using namespace node;
 
-class FixLoginResponse : public node::ObjectWrap {
+class FixLoginResponse : public Nan::ObjectWrap {
 public:
 	FixLoginResponse();
 	virtual ~FixLoginResponse();

--- a/src/FixMessageUtil.h
+++ b/src/FixMessageUtil.h
@@ -25,7 +25,7 @@ public:
 
 	static void addFixHeader(FIX::Message* message, Local<v8::Object> msg) {
 
-		Local<v8::Object> header = Local<v8::Object>::Cast(msg->Get(NanNew<String>("header")));
+		Local<v8::Object> header = Local<v8::Object>::Cast(msg->Get(Nan::New<String>("header").ToLocalChecked()));
 		FIX::Header &msgHeader = message->getHeader();
 		Local<v8::Array> headerTags = header->GetPropertyNames();
 
@@ -40,7 +40,7 @@ public:
 
 	static void addFixTags(FIX::FieldMap* map, Local<v8::Object> msg) {
 
-		Local<v8::String> tagsKey = NanNew<v8::String>("tags");
+		Local<v8::String> tagsKey = Nan::New<v8::String>("tags").ToLocalChecked();
 
 		if(msg->Has(tagsKey)) {
 
@@ -63,7 +63,7 @@ public:
 	}
 
 	static void addFixGroups(FIX::FieldMap* map, Local<v8::Object> msg) {
-		Local<v8::String> groupKey = NanNew<v8::String>("groups");
+		Local<v8::String> groupKey = Nan::New<v8::String>("groups").ToLocalChecked();
 
 		// TODO: add type checking and dev-helpful error throwing
 
@@ -78,22 +78,22 @@ public:
 
 				Local<v8::Object> groupObj = groups->Get(i)->ToObject();
 
-				Local<v8::String> delimKey = NanNew<v8::String>("delim");
-				Local<v8::String> indexKey = NanNew<v8::String>("index");
+				Local<v8::String> delimKey = Nan::New<v8::String>("delim").ToLocalChecked();
+				Local<v8::String> indexKey = Nan::New<v8::String>("index").ToLocalChecked();
 
 				if( ! groupObj->Has(indexKey)) {
-						NanThrowError("no index property found on object");
+						Nan::ThrowError("no index property found on object");
 				}
 
 				if( ! groupObj->Has(delimKey)) {
-						NanThrowError("no delim property found on object");
+						Nan::ThrowError("no delim property found on object");
 				}
 
 
-				Local<v8::String> entriesKey = NanNew<v8::String>("entries");
+				Local<v8::String> entriesKey = Nan::New<v8::String>("entries").ToLocalChecked();
 
 				if( ! groupObj->Has(entriesKey)) {
-						NanThrowError("no entries property found on object");
+						Nan::ThrowError("no entries property found on object");
 				}
 
 				Local<v8::Array> groupEntries = Local<v8::Array>::Cast(groupObj->Get(entriesKey));
@@ -102,7 +102,7 @@ public:
 
 					Local<v8::Object> entry = groupEntries->Get(j)->ToObject();
 
-					Local<v8::String> tagKey = NanNew<v8::String>("tags");
+					Local<v8::String> tagKey = Nan::New<v8::String>("tags").ToLocalChecked();
 
 					if(entry->Has(groupKey) || entry->Has(tagKey)) {
 
@@ -151,7 +151,7 @@ public:
 
 		FIX::Trailer &msgTrailer = message->getTrailer();
 
-		Local<v8::String> trailerKey = NanNew<v8::String>("trailer");
+		Local<v8::String> trailerKey = Nan::New<v8::String>("trailer").ToLocalChecked();
 
 		if(msg->Has(trailerKey)) {
 
@@ -186,55 +186,55 @@ public:
 	}
 
 	static void addJsHeader(Local<v8::Object> msg, const FIX::Message* message) {
-		Local<v8::Object> header = NanNew<v8::Object>();
+		Local<v8::Object> header = Nan::New<v8::Object>();
 		FIX::Header messageHeader = message->getHeader();
 
 		for(FIX::FieldMap::iterator it = messageHeader.begin(); it != messageHeader.end(); ++it)
 		{
-			header->Set(NanNew<Integer>(it->first), NanNew<v8::String>(it->second.getString().c_str()));
+			header->Set(Nan::New<Integer>(it->first), Nan::New<v8::String>(it->second.getString().c_str()).ToLocalChecked());
 		}
 
-		msg->Set(NanNew<v8::String>("header"), header);
+		msg->Set(Nan::New<v8::String>("header").ToLocalChecked(), header);
 	}
 
 	static void addJsTags(Local<v8::Object> msg, const FIX::FieldMap* map) {
-		Local<v8::Object> tags = NanNew<v8::Object>();
+		Local<v8::Object> tags = Nan::New<v8::Object>();
 		int noTags = 0;
 
 		for(FIX::FieldMap::iterator it = map->begin(); it != map->end(); ++it)
 		{
-			tags->Set(NanNew<Integer>(it->first), NanNew<v8::String>(it->second.getString().c_str()));
+			tags->Set(Nan::New<Integer>(it->first), Nan::New<v8::String>(it->second.getString().c_str()).ToLocalChecked());
 			noTags++;
 		}
 
 		if (noTags > 0) {
-			msg->Set(NanNew<v8::String>("tags"), tags);
+			msg->Set(Nan::New<v8::String>("tags").ToLocalChecked(), tags);
 		}
 	}
 
 	static void addJsTrailer(Local<v8::Object> msg, const FIX::Message* message) {
-		Local<v8::Object> trailer = NanNew<v8::Object>();
+		Local<v8::Object> trailer = Nan::New<v8::Object>();
 		FIX::Trailer messageTrailer = message->getTrailer();
 
 		for(FIX::FieldMap::iterator it = messageTrailer.begin(); it != messageTrailer.end(); ++it)
 		{
-			trailer->Set(NanNew<Integer>(it->first), NanNew<v8::String>(it->second.getString().c_str()));
+			trailer->Set(Nan::New<Integer>(it->first), Nan::New<v8::String>(it->second.getString().c_str()).ToLocalChecked());
 		}
 
-		msg->Set(NanNew<v8::String>("trailer"), trailer);
+		msg->Set(Nan::New<v8::String>("trailer").ToLocalChecked(), trailer);
 	}
 
 	static void addJsGroups(Local<v8::Object> msg, const FIX::FieldMap* map) {
-		Local<v8::Object> groups = NanNew<v8::Object>();
+		Local<v8::Object> groups = Nan::New<v8::Object>();
 		int noGroups = 0;
 
 		for(FIX::FieldMap::g_iterator it = map->g_begin(); it != map->g_end(); ++it) {
 			std::vector< FIX::FieldMap* > groupVector = it->second;
-			Handle<v8::Array> groupList = NanNew<v8::Array>(groupVector.size());
+			Handle<v8::Array> groupList = Nan::New<v8::Array>(groupVector.size());
 			int i = 0;
 
 			for(std::vector< FIX::FieldMap* >::iterator v_it = groupVector.begin(); v_it != groupVector.end(); ++v_it) {
-				Local<v8::Object> groupEntry = NanNew<v8::Object>();
+				Local<v8::Object> groupEntry = Nan::New<v8::Object>();
 
 				FIX::FieldMap* fields = *v_it;
 
@@ -247,13 +247,13 @@ public:
 				i++;
 			}
 
-			groups->Set(NanNew<Integer>(it->first), groupList);
+			groups->Set(Nan::New<Integer>(it->first), groupList);
 
 			noGroups++;
 		}
 
 		if (noGroups > 0) {
-			msg->Set(NanNew<v8::String>("groups"), groups);
+			msg->Set(Nan::New<v8::String>("groups").ToLocalChecked(), groups);
 		}
 	}
 
@@ -270,20 +270,20 @@ public:
 	}
 
 	static Local<Value> sessionIdToJs(const FIX::SessionID* sessionId) {
-		Local<v8::Object> session = NanNew<v8::Object>();
+		Local<v8::Object> session = Nan::New<v8::Object>();
 
-		session->Set(NanNew<v8::String>("beginString"), NanNew<v8::String>(sessionId->getBeginString().getString().c_str()));
-		session->Set(NanNew<v8::String>("senderCompID"), NanNew<v8::String>(sessionId->getSenderCompID().getString().c_str()));
-		session->Set(NanNew<v8::String>("targetCompID"), NanNew<v8::String>(sessionId->getTargetCompID().getString().c_str()));
-		session->Set(NanNew<v8::String>("sessionQualifier"), NanNew<v8::String>(sessionId->getSessionQualifier().c_str()));
+		session->Set(Nan::New<v8::String>("beginString").ToLocalChecked(), Nan::New<v8::String>(sessionId->getBeginString().getString().c_str()).ToLocalChecked());
+		session->Set(Nan::New<v8::String>("senderCompID").ToLocalChecked(), Nan::New<v8::String>(sessionId->getSenderCompID().getString().c_str()).ToLocalChecked());
+		session->Set(Nan::New<v8::String>("targetCompID").ToLocalChecked(), Nan::New<v8::String>(sessionId->getTargetCompID().getString().c_str()).ToLocalChecked());
+		session->Set(Nan::New<v8::String>("sessionQualifier").ToLocalChecked(), Nan::New<v8::String>(sessionId->getSessionQualifier().c_str()).ToLocalChecked());
 
 		return session;
 	}
 
 	static FIX::SessionID jsToSessionId(Local<v8::Object> sessionId) {
-		String::Utf8Value beginString(sessionId->Get(NanNew<v8::String>("beginString"))->ToString());
-		String::Utf8Value senderCompId(sessionId->Get(NanNew<v8::String>("senderCompID"))->ToString());
-		String::Utf8Value targetCompId(sessionId->Get(NanNew<v8::String>("targetCompID"))->ToString());
+		String::Utf8Value beginString(sessionId->Get(Nan::New<v8::String>("beginString").ToLocalChecked())->ToString());
+		String::Utf8Value senderCompId(sessionId->Get(Nan::New<v8::String>("senderCompID").ToLocalChecked())->ToString());
+		String::Utf8Value targetCompId(sessionId->Get(Nan::New<v8::String>("targetCompID").ToLocalChecked())->ToString());
 		return FIX::SessionID(std::string(*beginString),
 				std::string(*senderCompId),
 				std::string(*targetCompId));

--- a/src/FixSendWorker.cpp
+++ b/src/FixSendWorker.cpp
@@ -32,11 +32,11 @@ void FixSendWorker::Execute () {
 // this function will be run inside the main event loop
 // so it is safe to use V8 again
 void FixSendWorker::HandleOKCallback () {
-	NanScope();
+	Nan::HandleScope scope;
 
 	if(!callback->IsEmpty()) {
 		Local<Value> argv[] = {
-			NanNull()
+			Nan::Null()
 		};
 
 		callback->Call(1, argv);

--- a/src/FixSendWorker.h
+++ b/src/FixSendWorker.h
@@ -11,11 +11,11 @@
 using namespace v8;
 using namespace node;
 
-class FixSendWorker : public NanAsyncWorker
+class FixSendWorker : public Nan::AsyncWorker
 {
 	public:
-		FixSendWorker(NanCallback *callback, FIX::Message* message)
-			: NanAsyncWorker(callback), message(message) {}
+		FixSendWorker(Nan::Callback *callback, FIX::Message* message)
+			: Nan::AsyncWorker(callback), message(message) {}
 		~FixSendWorker() {
 			if(message) {
 				delete message;

--- a/src/FixSession.cpp
+++ b/src/FixSession.cpp
@@ -8,18 +8,18 @@
 #include "FixSession.h"
 #include "FixMessageUtil.h"
 
-class FixSessionAsyncWorker : public NanAsyncWorker {
+class FixSessionAsyncWorker : public Nan::AsyncWorker {
 	public:
-		FixSessionAsyncWorker(NanCallback *callback, FIX::Session* session)
-			: NanAsyncWorker(callback), session(session) {}
+		FixSessionAsyncWorker(Nan::Callback *callback, FIX::Session* session)
+			: Nan::AsyncWorker(callback), session(session) {}
 		~FixSessionAsyncWorker() {}
 
 		void HandleOKCallback () {
-			NanScope();
+			Nan::HandleScope scope;
 
 			if(!callback->IsEmpty()) {
 				Local<Value> argv[] = {
-					NanNull()
+					Nan::Null()
 				};
 
 				callback->Call(1, argv);
@@ -32,7 +32,7 @@ class FixSessionAsyncWorker : public NanAsyncWorker {
 
 class FixSessionDisconnectWorker : public FixSessionAsyncWorker {
 	public:
-		FixSessionDisconnectWorker(NanCallback *callback, FIX::Session* session)
+		FixSessionDisconnectWorker(Nan::Callback *callback, FIX::Session* session)
 				: FixSessionAsyncWorker(callback, session) {}
 		~FixSessionDisconnectWorker() {}
 
@@ -43,7 +43,7 @@ class FixSessionDisconnectWorker : public FixSessionAsyncWorker {
 
 class FixSessionLogonWorker : public FixSessionAsyncWorker {
 	public:
-		FixSessionLogonWorker(NanCallback *callback, FIX::Session* session)
+		FixSessionLogonWorker(Nan::Callback *callback, FIX::Session* session)
 				: FixSessionAsyncWorker(callback, session) {}
 		~FixSessionLogonWorker() {}
 
@@ -54,7 +54,7 @@ class FixSessionLogonWorker : public FixSessionAsyncWorker {
 
 class FixSessionLogoutWorker : public FixSessionAsyncWorker {
 	public:
-		FixSessionLogoutWorker(NanCallback *callback, FIX::Session* session)
+		FixSessionLogoutWorker(Nan::Callback *callback, FIX::Session* session)
 				: FixSessionAsyncWorker(callback, session) {}
 		~FixSessionLogoutWorker() {}
 
@@ -65,7 +65,7 @@ class FixSessionLogoutWorker : public FixSessionAsyncWorker {
 
 class FixSessionRefreshWorker : public FixSessionAsyncWorker {
 	public:
-		FixSessionRefreshWorker(NanCallback *callback, FIX::Session* session)
+		FixSessionRefreshWorker(Nan::Callback *callback, FIX::Session* session)
 				: FixSessionAsyncWorker(callback, session) {}
 		~FixSessionRefreshWorker() {}
 
@@ -76,7 +76,7 @@ class FixSessionRefreshWorker : public FixSessionAsyncWorker {
 
 class FixSessionResetWorker : public FixSessionAsyncWorker {
 	public:
-		FixSessionResetWorker(NanCallback *callback, FIX::Session* session)
+		FixSessionResetWorker(Nan::Callback *callback, FIX::Session* session)
 				: FixSessionAsyncWorker(callback, session) {}
 		~FixSessionResetWorker() {}
 
@@ -85,7 +85,7 @@ class FixSessionResetWorker : public FixSessionAsyncWorker {
 		};
 };
 
-FixSession::FixSession() : ObjectWrap() {
+FixSession::FixSession() : Nan::ObjectWrap() {
 }
 
 FixSession::~FixSession() {
@@ -96,174 +96,174 @@ void FixSession::setSession(FIX::Session* session) {
 }
 
 void FixSession::Initialize(Handle<Object> target) {
-	NanScope();
+	Nan::HandleScope scope;
 
-	Local<FunctionTemplate> ctor = NanNew<FunctionTemplate>(FixSession::New);
+	Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(FixSession::New);
 
 	ctor->InstanceTemplate()->SetInternalFieldCount(1);
-	ctor->SetClassName(NanNew("FixSession"));
+	ctor->SetClassName(Nan::New("FixSession").ToLocalChecked());
 
 	Local<ObjectTemplate> proto = ctor->PrototypeTemplate();
 
-	NODE_SET_PROTOTYPE_METHOD(ctor, "disconnect", disconnect);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "getSessionID", getSessionID);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "isEnabled", isEnabled);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "isLoggedOn", isLoggedOn);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "logon", logon);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "logout", logout);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "refresh", refresh);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "reset", reset);
+	Nan::SetPrototypeMethod(ctor, "disconnect", disconnect);
+	Nan::SetPrototypeMethod(ctor, "getSessionID", getSessionID);
+	Nan::SetPrototypeMethod(ctor, "isEnabled", isEnabled);
+	Nan::SetPrototypeMethod(ctor, "isLoggedOn", isLoggedOn);
+	Nan::SetPrototypeMethod(ctor, "logon", logon);
+	Nan::SetPrototypeMethod(ctor, "logout", logout);
+	Nan::SetPrototypeMethod(ctor, "refresh", refresh);
+	Nan::SetPrototypeMethod(ctor, "reset", reset);
 
-	proto->SetAccessor(NanNew("senderSeqNum"), getSenderSeqNum, setSenderSeqNum);
-	proto->SetAccessor(NanNew("targetSeqNum"), getTargetSeqNum, setTargetSeqNum);
+	Nan::SetAccessor(proto, Nan::New("senderSeqNum").ToLocalChecked(), getSenderSeqNum, setSenderSeqNum);
+	Nan::SetAccessor(proto, Nan::New("targetSeqNum").ToLocalChecked(), getTargetSeqNum, setTargetSeqNum);
 
-	target->Set(NanNew("FixSession"), ctor->GetFunction());
+	target->Set(Nan::New("FixSession").ToLocalChecked(), ctor->GetFunction());
 }
 
 Handle<Object> FixSession::wrapFixSession(FixSession* fixSession) {
-	Local<FunctionTemplate> ctor = NanNew<FunctionTemplate>();
+	Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>();
 
 	ctor->InstanceTemplate()->SetInternalFieldCount(1);
-	ctor->SetClassName(NanNew("FixSession"));
+	ctor->SetClassName(Nan::New("FixSession").ToLocalChecked());
 
 	Local<ObjectTemplate> proto = ctor->PrototypeTemplate();
 
-	NODE_SET_PROTOTYPE_METHOD(ctor, "disconnect", disconnect);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "getSessionID", getSessionID);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "isEnabled", isEnabled);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "isLoggedOn", isLoggedOn);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "logon", logon);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "logout", logout);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "refresh", refresh);
-	NODE_SET_PROTOTYPE_METHOD(ctor, "reset", reset);
+	Nan::SetPrototypeMethod(ctor, "disconnect", disconnect);
+	Nan::SetPrototypeMethod(ctor, "getSessionID", getSessionID);
+	Nan::SetPrototypeMethod(ctor, "isEnabled", isEnabled);
+	Nan::SetPrototypeMethod(ctor, "isLoggedOn", isLoggedOn);
+	Nan::SetPrototypeMethod(ctor, "logon", logon);
+	Nan::SetPrototypeMethod(ctor, "logout", logout);
+	Nan::SetPrototypeMethod(ctor, "refresh", refresh);
+	Nan::SetPrototypeMethod(ctor, "reset", reset);
 
-	proto->SetAccessor(NanNew("senderSeqNum"), getSenderSeqNum, setSenderSeqNum);
-	proto->SetAccessor(NanNew("targetSeqNum"), getTargetSeqNum, setTargetSeqNum);
+	Nan::SetAccessor(proto, Nan::New("senderSeqNum").ToLocalChecked(), getSenderSeqNum, setSenderSeqNum);
+	Nan::SetAccessor(proto, Nan::New("targetSeqNum").ToLocalChecked(), getTargetSeqNum, setTargetSeqNum);
 
 	Handle<Object> obj = ctor->InstanceTemplate()->NewInstance();
 
-	//obj->SetAlignedPointerInInternalField(0, NanNew<External>(fixSession));
+	//obj->SetAlignedPointerInInternalField(0, Nan::New<External>(fixSession));
 	fixSession->Wrap(obj);
 	return obj;
 }
 
 NAN_METHOD(FixSession::New) {
-	NanScope();
+	Nan::HandleScope scope;
 
 	FixSession *fixSession = new FixSession();
 
-	fixSession->Wrap(args.This());
+	fixSession->Wrap(info.This());
 
-	NanReturnValue(args.This());
+	info.GetReturnValue().Set(info.This());
 }
 
 NAN_METHOD(FixSession::isEnabled) {
-	NanScope();
+	Nan::HandleScope scope;
 
-	FixSession* instance = ObjectWrap::Unwrap<FixSession>(args.Holder());
+	FixSession* instance = Nan::ObjectWrap::Unwrap<FixSession>(info.Holder());
 	bool isEnabled = instance->mSession->isEnabled();
 
-	NanReturnValue(isEnabled ? NanTrue() : NanFalse());
+	info.GetReturnValue().Set(isEnabled ? Nan::True() : Nan::False());
 }
 
 NAN_METHOD(FixSession::isLoggedOn) {
-	NanScope();
+	Nan::HandleScope scope;
 
-	FixSession* instance = ObjectWrap::Unwrap<FixSession>(args.Holder());
+	FixSession* instance = Nan::ObjectWrap::Unwrap<FixSession>(info.Holder());
 	bool isLoggedOn = instance->mSession->isLoggedOn();
 
-	NanReturnValue(isLoggedOn ? NanTrue() : NanFalse());
+	info.GetReturnValue().Set(isLoggedOn ? Nan::True() : Nan::False());
 }
 
 NAN_METHOD(FixSession::getSessionID) {
-	NanScope();
+	Nan::HandleScope scope;
 
-	FixSession* instance = ObjectWrap::Unwrap<FixSession>(args.Holder());
+	FixSession* instance = Nan::ObjectWrap::Unwrap<FixSession>(info.Holder());
 	FIX::SessionID sessionId = instance->mSession->getSessionID();
 	Handle<Value> jsSessionId = FixMessageUtil::sessionIdToJs(&sessionId);
 
-	NanReturnValue(jsSessionId);
+	info.GetReturnValue().Set(jsSessionId);
 }
 
 NAN_METHOD(FixSession::disconnect) {
-	NanScope();
+	Nan::HandleScope scope;
 
-	FixSession* instance = ObjectWrap::Unwrap<FixSession>(args.Holder());
-	NanCallback *callback = new NanCallback(args[0].As<Function>());
+	FixSession* instance = Nan::ObjectWrap::Unwrap<FixSession>(info.Holder());
+	Nan::Callback *callback = new Nan::Callback(info[0].As<Function>());
 
-	NanAsyncQueueWorker(new FixSessionDisconnectWorker(callback, instance->mSession));
+	Nan::AsyncQueueWorker(new FixSessionDisconnectWorker(callback, instance->mSession));
 
-	NanReturnUndefined();
+	return;
 }
 
 NAN_METHOD(FixSession::logon) {
-	NanScope();
+	Nan::HandleScope scope;
 
-	FixSession* instance = ObjectWrap::Unwrap<FixSession>(args.Holder());
-	NanCallback *callback = new NanCallback(args[0].As<Function>());
+	FixSession* instance = Nan::ObjectWrap::Unwrap<FixSession>(info.Holder());
+	Nan::Callback *callback = new Nan::Callback(info[0].As<Function>());
 
-	NanAsyncQueueWorker(new FixSessionLogonWorker(callback, instance->mSession));
+	Nan::AsyncQueueWorker(new FixSessionLogonWorker(callback, instance->mSession));
 
-	NanReturnUndefined();
+	return;
 }
 
 NAN_METHOD(FixSession::logout) {
-	NanScope();
+	Nan::HandleScope scope;
 
-	FixSession* instance = ObjectWrap::Unwrap<FixSession>(args.Holder());
-	NanCallback *callback = new NanCallback(args[0].As<Function>());
+	FixSession* instance = Nan::ObjectWrap::Unwrap<FixSession>(info.Holder());
+	Nan::Callback *callback = new Nan::Callback(info[0].As<Function>());
 
-	NanAsyncQueueWorker(new FixSessionLogoutWorker(callback, instance->mSession));
+	Nan::AsyncQueueWorker(new FixSessionLogoutWorker(callback, instance->mSession));
 
-	NanReturnUndefined();
+	return;
 }
 
 NAN_METHOD(FixSession::refresh) {
-	NanScope();
+	Nan::HandleScope scope;
 
-	FixSession* instance = ObjectWrap::Unwrap<FixSession>(args.Holder());
-	NanCallback *callback = new NanCallback(args[0].As<Function>());
+	FixSession* instance = Nan::ObjectWrap::Unwrap<FixSession>(info.Holder());
+	Nan::Callback *callback = new Nan::Callback(info[0].As<Function>());
 
-	NanAsyncQueueWorker(new FixSessionRefreshWorker(callback, instance->mSession));
+	Nan::AsyncQueueWorker(new FixSessionRefreshWorker(callback, instance->mSession));
 
-	NanReturnUndefined();
+	return;
 }
 
 NAN_METHOD(FixSession::reset) {
-	NanScope();
+	Nan::HandleScope scope;
 
-	FixSession* instance = ObjectWrap::Unwrap<FixSession>(args.Holder());
-	NanCallback *callback = new NanCallback(args[0].As<Function>());
+	FixSession* instance = Nan::ObjectWrap::Unwrap<FixSession>(info.Holder());
+	Nan::Callback *callback = new Nan::Callback(info[0].As<Function>());
 
-	NanAsyncQueueWorker(new FixSessionResetWorker(callback, instance->mSession));
+	Nan::AsyncQueueWorker(new FixSessionResetWorker(callback, instance->mSession));
 
-	NanReturnUndefined();
+	return;
 }
 
 NAN_GETTER(FixSession::getSenderSeqNum) {
-	NanScope();
-	FixSession* instance = ObjectWrap::Unwrap<FixSession>(args.Holder());
-	NanReturnValue(NanNew<Number>(instance->mSession->getExpectedSenderNum()));
+	Nan::HandleScope scope;
+	FixSession* instance = Nan::ObjectWrap::Unwrap<FixSession>(info.Holder());
+	info.GetReturnValue().Set(Nan::New<Number>(instance->mSession->getExpectedSenderNum()));
 }
 
 NAN_SETTER(FixSession::setSenderSeqNum) {
-	NanScope();
+	Nan::HandleScope scope;
 	if(value->IsNumber()) {
-		FixSession* instance = ObjectWrap::Unwrap<FixSession>(args.Holder());
+		FixSession* instance = Nan::ObjectWrap::Unwrap<FixSession>(info.Holder());
 		instance->mSession->setNextSenderMsgSeqNum(value->Uint32Value());
 	}
 }
 
 NAN_GETTER(FixSession::getTargetSeqNum) {
-	NanScope();
-	FixSession* instance = ObjectWrap::Unwrap<FixSession>(args.Holder());
-	NanReturnValue(NanNew<Number>(instance->mSession->getExpectedTargetNum()));
+	Nan::HandleScope scope;
+	FixSession* instance = Nan::ObjectWrap::Unwrap<FixSession>(info.Holder());
+	info.GetReturnValue().Set(Nan::New<Number>(instance->mSession->getExpectedTargetNum()));
 }
 
 NAN_SETTER(FixSession::setTargetSeqNum) {
-	NanScope();
+	Nan::HandleScope scope;
 	if(value->IsNumber()) {
-		FixSession* instance = ObjectWrap::Unwrap<FixSession>(args.Holder());
+		FixSession* instance = Nan::ObjectWrap::Unwrap<FixSession>(info.Holder());
 		instance->mSession->setNextTargetMsgSeqNum(value->Uint32Value());
 	}
 }

--- a/src/FixSession.h
+++ b/src/FixSession.h
@@ -17,7 +17,7 @@
 using namespace v8;
 using namespace node;
 
-class FixSession : public node::ObjectWrap {
+class FixSession : public Nan::ObjectWrap {
 public:
 	FixSession();
 	static void Initialize(v8::Handle<v8::Object> target);

--- a/src/node_quickfix.cpp
+++ b/src/node_quickfix.cpp
@@ -6,18 +6,18 @@
 using namespace v8;
 
 NAN_METHOD(Initiator) {
-  NanScope();
-  FixInitiator::New(args);
+  Nan::HandleScope scope;
+  FixInitiator::New(info);
 }
 
 NAN_METHOD(Acceptor) {
-  NanScope();
-  FixAcceptor::New(args);
+  Nan::HandleScope scope;
+  FixAcceptor::New(info);
 }
 
 NAN_METHOD(LoginProvider) {
-  NanScope();
-  FixLoginProvider::New(args);
+  Nan::HandleScope scope;
+  FixLoginProvider::New(info);
 }
 
 void init(Handle<Object> target) {


### PR DESCRIPTION
Unfortunately commit e5bb017abc72329f595914219ba61aec6dee4ba3 wasn't sufficient in order to achieve support for Node.js v4.2.2 LTS and v5.1.0. In order to accomplish this the bindings required updating to the latest NAN and V8 API's. I've taken care of these modifications in this pull request.

The modifications were successfully tested on Node.js v4.2.2 LTS and v5.1.0 running on OS X 10.11. All the unit tests pass as well. As I haven't got `node-quickfix` running in production yet it hasn't been tested in production though. Please note that this version is incompatible with Node.js v0.12, therefore the package version has been incremented to v2.0.0.