### PR TITLE
Fix for Assertion failure in getters/setters + more detailed examples

### DIFF
--- a/examples/acceptorExample.js
+++ b/examples/acceptorExample.js
@@ -1,6 +1,7 @@
 var events = require('events');
 var path = require('path');
 var quickfix = require('../index');
+var common = require('./common');
 var fixAcceptor = quickfix.acceptor;
 
 var logonProvider = new quickfix.logonProvider(function (logonResponse, msg, sessionId) {	
@@ -22,25 +23,25 @@ inherits(fixAcceptor, events.EventEmitter);
 var fixServer = new fixAcceptor(
 {
   onCreate: function(sessionID) {
-    fixServer.emit('onCreate', { sessionID: sessionID });
+    fixServer.emit('onCreate', common.stats(fixServer, sessionID));
   },
   onLogon: function(sessionID) {
-    fixServer.emit('onLogon', { sessionID: sessionID });
+    fixServer.emit('onLogon', common.stats(fixServer, sessionID));
   },
   onLogout: function(sessionID) {
-    fixServer.emit('onLogout', { sessionID: sessionID });
+    fixServer.emit('onLogout', common.stats(fixServer, sessionID));
   },
   onLogonAttempt: function(message, sessionID) {
-    fixServer.emit('onLogonAttempt', { message: message, sessionID: sessionID });
+    fixServer.emit('onLogonAttempt', common.stats(fixServer, sessionID, message));
   },
   toAdmin: function(message, sessionID) {
-    fixServer.emit('toAdmin', { message: message, sessionID: sessionID });
+    fixServer.emit('toAdmin', common.stats(fixServer, sessionID, message));
   },
   fromAdmin: function(message, sessionID) {
-    fixServer.emit('fromAdmin', { message: message, sessionID: sessionID });
+    fixServer.emit('fromAdmin', common.stats(fixServer, sessionID, message));
   },
   fromApp: function(message, sessionID) {
-    fixServer.emit('fromApp', { message: message, sessionID: sessionID });
+    fixServer.emit('fromApp', common.stats(fixServer, sessionID, message));
   }
 }, {
   logonProvider: logonProvider, 
@@ -59,5 +60,6 @@ var fixServer = new fixAcceptor(
 
 fixServer.start(function() {
 	console.log("FIX Acceptor Started");
+  common.printStats(fixServer);
   process.stdin.resume();
 });

--- a/examples/common.js
+++ b/examples/common.js
@@ -1,0 +1,22 @@
+function stats(fixentity, sessionID, message) {
+  var sess = fixentity.getSession(sessionID);
+  var ret = {
+    sessionID: sessionID,
+    senderSeqNum: sess.senderSeqNum,
+    targetSeqNum: sess.targetSeqNum
+  };
+  if (message) {
+    ret.message = message;
+  }
+  return ret;
+}
+
+function printStats(fixentity){
+  var sess = fixentity.getSession(fixentity.getSessions()[0]);
+  console.log('senderSeqNum', sess.senderSeqNum, 'targetSeqNum', sess.targetSeqNum);
+}
+
+module.exports = {
+  stats: stats,
+  printStats: printStats
+};

--- a/examples/initiatorExample.js
+++ b/examples/initiatorExample.js
@@ -1,6 +1,7 @@
 var df = require('dateformat');
 var events = require('events');
 var quickfix = require('../index');
+var common = require('./common');
 var initiator = quickfix.initiator;
 
 var options = {
@@ -23,25 +24,25 @@ inherits(initiator, events.EventEmitter);
 var fixClient = new initiator(
 {
   onCreate: function(sessionID) {
-    fixClient.emit('onCreate', { sessionID: sessionID });
+    fixClient.emit('onCreate', common.stats(fixClient, sessionID));
   },
   onLogon: function(sessionID) {
-    fixClient.emit('onLogon', { sessionID: sessionID });
+    fixClient.emit('onLogon', common.stats(fixClient, sessionID));
   },
   onLogout: function(sessionID) {
-    fixClient.emit('onLogout', { sessionID: sessionID });
+    fixClient.emit('onLogout', common.stats(fixClient, sessionID));
   },
   onLogonAttempt: function(message, sessionID) {
-    fixClient.emit('onLogonAttempt', { message: message, sessionID: sessionID });
+    fixClient.emit('onLogonAttempt', common.stats(fixClient, sessionID, message));
   },
   toAdmin: function(message, sessionID) {
-    fixClient.emit('toAdmin', { message: message, sessionID: sessionID });
+    fixClient.emit('toAdmin', common.stats(fixClient, sessionID, message));
   },
   fromAdmin: function(message, sessionID) {
-    fixClient.emit('fromAdmin', { message: message, sessionID: sessionID });
+    fixClient.emit('fromAdmin', common.stats(fixClient, sessionID, message));
   },
   fromApp: function(message, sessionID) {
-    fixClient.emit('fromApp', { message: message, sessionID: sessionID });
+    fixClient.emit('fromApp', common.stats(fixClient, sessionID, message));
   }
 }, options);
 
@@ -70,6 +71,7 @@ fixClient.start(function() {
 
   fixClient.send(order, function() {
     console.log("Order sent!");
+    common.printStats(fixClient);
     process.stdin.resume();
   });
 });

--- a/src/FixSession.cpp
+++ b/src/FixSession.cpp
@@ -242,28 +242,28 @@ NAN_METHOD(FixSession::reset) {
 
 NAN_GETTER(FixSession::getSenderSeqNum) {
 	NanScope();
-	FixSession* instance = ObjectWrap::Unwrap<FixSession>(args.Holder());
+	FixSession* instance = ObjectWrap::Unwrap<FixSession>(args.This());
 	NanReturnValue(NanNew<Number>(instance->mSession->getExpectedSenderNum()));
 }
 
 NAN_SETTER(FixSession::setSenderSeqNum) {
 	NanScope();
 	if(value->IsNumber()) {
-		FixSession* instance = ObjectWrap::Unwrap<FixSession>(args.Holder());
+		FixSession* instance = ObjectWrap::Unwrap<FixSession>(args.This());
 		instance->mSession->setNextSenderMsgSeqNum(value->Uint32Value());
 	}
 }
 
 NAN_GETTER(FixSession::getTargetSeqNum) {
 	NanScope();
-	FixSession* instance = ObjectWrap::Unwrap<FixSession>(args.Holder());
+	FixSession* instance = ObjectWrap::Unwrap<FixSession>(args.This());
 	NanReturnValue(NanNew<Number>(instance->mSession->getExpectedTargetNum()));
 }
 
 NAN_SETTER(FixSession::setTargetSeqNum) {
 	NanScope();
 	if(value->IsNumber()) {
-		FixSession* instance = ObjectWrap::Unwrap<FixSession>(args.Holder());
+		FixSession* instance = ObjectWrap::Unwrap<FixSession>(args.This());
 		instance->mSession->setNextTargetMsgSeqNum(value->Uint32Value());
 	}
 }


### PR DESCRIPTION
The proposed solution gets rid of the notorious
```
node: /home/xyz/.node-gyp/0.12.7/src/node_object_wrap.h:50: static T* node::ObjectWrap::Unwrap(v8::Handle<v8::Object>) [with T = FixSession]: Assertion `handle->InternalFieldCount() > 0' failed
```
error and immediate/unavoidable application crash.

In order to prove what's going on, examples are augmented with helpers for constant tracking of the senderSeqNum/targetSeqNum.