### PR TITLE
Fix memory leaks in src/Dispatcher.h

### DIFF
--- a/src/Dispatcher.h
+++ b/src/Dispatcher.h
@@ -63,6 +63,9 @@ class Dispatcher {
             }
 
             Nan::MakeCallback(Nan::GetCurrentContext()->Global(), callback, arguments.size(), &arguments[0]);
+
+            delete event->message;
+            delete event;
         }
     }
 

--- a/src/Dispatcher.h
+++ b/src/Dispatcher.h
@@ -58,13 +58,13 @@ class Dispatcher {
                 arguments.push_back(msg);
                 arguments.push_back(FixMessageUtil::sessionIdToJs(event->sessionId));
 
+                delete event->message;
             } else {
                 arguments.push_back(FixMessageUtil::sessionIdToJs(event->sessionId));
             }
 
             Nan::MakeCallback(Nan::GetCurrentContext()->Global(), callback, arguments.size(), &arguments[0]);
 
-            delete event->message;
             delete event;
         }
     }


### PR DESCRIPTION
Hi,

We are seeing a memory leak while sending a large amount of orders. We modified the example initiator and acceptor and Postgres integration was enabled.

I used valgrind on the acceptor with the following command:
`valgrind --leak-check=yes /home/james/.nvm/versions/node/v4.3.1/bin/node app.js`

I sent exactly 10,000 order messages for each test pass.

### Valgrind output before change

> ==32072== 878,260 (26,592 direct, 851,668 indirect) bytes in 554 blocks are definitely lost in loss record 6,101 of 6,101
> ==32072==    at 0x4C2B0E0: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
> ==32072==    by 0x986B818: FixApplication::dispatchEvent(std::string, FIX::Message const&, FIX::SessionID const&) (FixApplication.cpp:101)
> ==32072==    by 0x986CC7F: FixApplication::fromApp(FIX::Message const&, FIX::SessionID const&) (FixApplication.cpp:92)
> ==32072==    by 0x9AC7C47: FIX::Session::verify(FIX::Message const&, bool, bool) (Session.cpp:1009)
> ==32072==    by 0x9ACC47A: FIX::Session::next(FIX::Message const&, FIX::UtcTimeStamp const&, bool) (Session.cpp:1271)
> ==32072==    by 0x9ACF3E2: FIX::Session::next(std::string const&, FIX::UtcTimeStamp const&, bool) (Session.cpp:1189)
> ==32072==    by 0x9B01723: FIX::ThreadedSocketConnection::processStream() (ThreadedSocketConnection.cpp:162)
> ==32072==    by 0x9B01932: FIX::ThreadedSocketConnection::read() (ThreadedSocketConnection.cpp:117)
> ==32072==    by 0x9AFABEF: FIX::ThreadedSocketAcceptor::socketConnectionThread(void*) (ThreadedSocketAcceptor.cpp:252)
> ==32072==    by 0x5A6B181: start_thread (pthread_create.c:312)
> ==32072==    by 0x5D7B47C: clone (clone.S:111)
> ==32072==
> ==32072== LEAK SUMMARY:
> ==32072==    definitely lost: 49,888 bytes in 821 blocks
> ==32072==    indirectly lost: 1,594,539 bytes in 23,957 blocks
> ==32072==      possibly lost: 241,555 bytes in 6,553 blocks
> ==32072==    still reachable: 7,034,359 bytes in 96,442 blocks
> ==32072==         suppressed: 0 bytes in 0 blocks

Note definitely lost + indirectly lost are about 1.64MB.

### Valgrind output after change
> ==1672== 93,836 bytes in 2,200 blocks are possibly lost in loss record 5,974 of 5,978
> ==1672==    at 0x4C2B0E0: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
> ==1672==    by 0x52FD248: std::string::_Rep::_S_create(unsigned long, unsigned long, std::allocator<char> const&) (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.19)
> ==1672==    by 0x52FD3D5: std::string::_M_mutate(unsigned long, unsigned long, unsigned long) (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.19)
> ==1672==    by 0x52FD97D: std::string::_M_replace_safe(unsigned long, unsigned long, char const*, unsigned long) (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.19)
> ==1672==    by 0x9B4E1B7: assign (basic_string.h:1131)
> ==1672==    by 0x9B4E1B7: operator= (basic_string.h:555)
> ==1672==    by 0x9B4E1B7: FIX::PUGIXML_DOMAttributes::get(std::string const&, std::string&) (PUGIXML_DOMDocument.cpp:35)
> ==1672==    by 0x9B1E0EE: FIX::DataDictionary::readFromDocument(std::auto_ptr<FIX::DOMDocument>) (DataDictionary.cpp:281)
> ==1672==    by 0x9B2123B: FIX::DataDictionary::readFromURL(std::string const&) (DataDictionary.cpp:201)
> ==1672==    by 0x9B2191A: FIX::DataDictionary::DataDictionary(std::string const&) (DataDictionary.cpp:60)
> ==1672==    by 0x9ADB466: FIX::SessionFactory::createDataDictionary(FIX::SessionID const&, FIX::Dictionary const&, std::string const&) (SessionFactory.cpp:219)
> ==1672==    by 0x9ADC448: FIX::SessionFactory::processFixDataDictionary(FIX::SessionID const&, FIX::Dictionary const&, FIX::DataDictionaryProvider&) (SessionFactory.cpp:270)
> ==1672==    by 0x9ADD3A6: FIX::SessionFactory::create(FIX::SessionID const&, FIX::Dictionary const&) (SessionFactory.cpp:74)
> ==1672==    by 0x9AED4B4: FIX::Acceptor::initialize() (Acceptor.cpp:85)
> ==1672==
> ==1672== LEAK SUMMARY:
> ==1672==    definitely lost: 0 bytes in 0 blocks
> ==1672==    indirectly lost: 0 bytes in 0 blocks
> ==1672==      possibly lost: 227,949 bytes in 6,348 blocks
> ==1672==    still reachable: 7,033,949 bytes in 96,433 blocks
> ==1672==         suppressed: 0 bytes in 0 blocks

The memory usage appears stable after this change.

Thanks for the library, it's great to have off-the-shelf node.js integration to QuickFix :-)
