### PR TITLE
Avoiding memory leaks

### DIFF
--- a/src/FixAcceptor.cpp
+++ b/src/FixAcceptor.cpp
@@ -202,14 +202,11 @@ NAN_METHOD(FixAcceptor::getSessions) {
 
 NAN_METHOD(FixAcceptor::getSession) {
 	Nan::HandleScope scope;
-	FixAcceptor* instance = Nan::ObjectWrap::Unwrap<FixAcceptor>(info.Holder());
+	FixAcceptor* instance = ObjectWrap::Unwrap<FixAcceptor>(info.Holder());
 	Local<Object> sessionId = info[0]->ToObject();
 
 	FIX::Session* session = instance->mAcceptor->getSession(FixMessageUtil::jsToSessionId(sessionId));
 
-	FixSession* fixSession = new FixSession();
-	fixSession->setSession(session);
-
-	Handle<Object> jsSession = FixSession::wrapFixSession(fixSession);
+	Handle<Object> jsSession(FixSession::wrapFixSession(session));
 	info.GetReturnValue().Set(jsSession);
 }

--- a/src/FixInitiator.cpp
+++ b/src/FixInitiator.cpp
@@ -209,15 +209,13 @@ NAN_METHOD(FixInitiator::getSessions) {
 
 NAN_METHOD(FixInitiator::getSession) {
 	Nan::HandleScope scope;
-	FixInitiator* instance = Nan::ObjectWrap::Unwrap<FixInitiator>(info.This());
+	FixInitiator* instance = ObjectWrap::Unwrap<FixInitiator>(info.This());
 
 	Local<Object> sessionId = info[0]->ToObject();
 
 	FIX::Session* session = instance->mInitiator->getSession(FixMessageUtil::jsToSessionId(sessionId));
-	FixSession* fixSession = new FixSession();
-	fixSession->setSession(session);
 
-	Handle<Object> jsSession = FixSession::wrapFixSession(fixSession);
+	Handle<Object> jsSession(FixSession::wrapFixSession(session));
 
 	info.GetReturnValue().Set(jsSession);
 }

--- a/src/FixInitiator.cpp
+++ b/src/FixInitiator.cpp
@@ -33,9 +33,9 @@ using namespace std;
  */
 
 void FixInitiator::Initialize(Handle<Object> target) {
-Nan::HandleScope scope;
+	Nan::HandleScope scope;
 
-Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(FixInitiator::New);
+	Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(FixInitiator::New);
 
 	// TODO:: Figure out what the compile error is with this
 	//constructor.Reset(ctor);

--- a/src/FixInitiator.cpp
+++ b/src/FixInitiator.cpp
@@ -33,25 +33,25 @@ using namespace std;
  */
 
 void FixInitiator::Initialize(Handle<Object> target) {
-  Nan::HandleScope scope;
+Nan::HandleScope scope;
 
-  Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(FixInitiator::New);
+Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(FixInitiator::New);
 
-  // TODO:: Figure out what the compile error is with this
-  //constructor.Reset(ctor);
+	// TODO:: Figure out what the compile error is with this
+	//constructor.Reset(ctor);
 
-  ctor->InstanceTemplate()->SetInternalFieldCount(1);
-  ctor->SetClassName(Nan::New("FixInitiator").ToLocalChecked());
+	ctor->InstanceTemplate()->SetInternalFieldCount(1);
+	ctor->SetClassName(Nan::New("FixInitiator").ToLocalChecked());
 
-  Nan::SetPrototypeMethod(ctor, "start", start);
-  Nan::SetPrototypeMethod(ctor, "send", send);
-  Nan::SetPrototypeMethod(ctor, "sendRaw", sendRaw);
-  Nan::SetPrototypeMethod(ctor, "stop", stop);
-  Nan::SetPrototypeMethod(ctor, "isLoggedOn", isLoggedOn);
-  Nan::SetPrototypeMethod(ctor, "getSessions", getSessions);
-  Nan::SetPrototypeMethod(ctor, "getSession", getSession);
+	Nan::SetPrototypeMethod(ctor, "start", start);
+	Nan::SetPrototypeMethod(ctor, "send", send);
+	Nan::SetPrototypeMethod(ctor, "sendRaw", sendRaw);
+	Nan::SetPrototypeMethod(ctor, "stop", stop);
+	Nan::SetPrototypeMethod(ctor, "isLoggedOn", isLoggedOn);
+	Nan::SetPrototypeMethod(ctor, "getSessions", getSessions);
+	Nan::SetPrototypeMethod(ctor, "getSession", getSession);
 
-  target->Set(Nan::New("FixInitiator").ToLocalChecked(), ctor->GetFunction());
+	target->Set(Nan::New("FixInitiator").ToLocalChecked(), ctor->GetFunction());
 }
 
 NAN_METHOD(FixInitiator::New) {

--- a/src/FixSession.cpp
+++ b/src/FixSession.cpp
@@ -119,16 +119,16 @@ void FixSession::Initialize() {
 	Nan::SetAccessor(proto, Nan::New("senderSeqNum").ToLocalChecked(), getSenderSeqNum, setSenderSeqNum);
 	Nan::SetAccessor(proto, Nan::New("targetSeqNum").ToLocalChecked(), getTargetSeqNum, setTargetSeqNum);
 
-  g_Ctor.Reset(ctor->GetFunction());
+	g_Ctor.Reset(ctor->GetFunction());
 }
 
 Handle<Object> FixSession::wrapFixSession(FIX::Session *session) {
-  Nan::EscapableHandleScope scope;
-  Local<Function> ctor = Nan::New<Function>(g_Ctor);
-  Local<Object> instance = ctor->NewInstance(0, {});
-  FixSession* fs = ObjectWrap::Unwrap<FixSession>(instance);
-  fs->setSession(session);
-  return scope.Escape(instance);
+	Nan::EscapableHandleScope scope;
+	Local<Function> ctor = Nan::New<Function>(g_Ctor);
+	Local<Object> instance = ctor->NewInstance(0, {});
+	FixSession* fs = ObjectWrap::Unwrap<FixSession>(instance);
+	fs->setSession(session);
+	return scope.Escape(instance);
 }
 
 NAN_METHOD(FixSession::New) {

--- a/src/FixSession.h
+++ b/src/FixSession.h
@@ -20,10 +20,10 @@ using namespace node;
 class FixSession : public Nan::ObjectWrap {
 public:
 	FixSession();
-	static void Initialize(v8::Handle<v8::Object> target);
+	static void Initialize();
 	static NAN_METHOD(New);
 	void setSession(FIX::Session* session);
-	static Handle<Object> wrapFixSession(FixSession* fixSession);
+	static Handle<Object> wrapFixSession(FIX::Session *session);
 
 private:
 	virtual ~FixSession();

--- a/src/node_quickfix.cpp
+++ b/src/node_quickfix.cpp
@@ -25,7 +25,7 @@ void init(Handle<Object> target) {
 	FixLoginProvider::Initialize(target);
 	FixInitiator::Initialize(target);
 	FixAcceptor::Initialize(target);
-  FixSession::Initialize();
+	FixSession::Initialize();
 }
 
 // Register the module with node.

--- a/src/node_quickfix.cpp
+++ b/src/node_quickfix.cpp
@@ -2,6 +2,7 @@
 #include <node.h>
 #include "FixInitiator.h"
 #include "FixAcceptor.h"
+#include "FixSession.h"
 
 using namespace v8;
 
@@ -24,6 +25,7 @@ void init(Handle<Object> target) {
 	FixLoginProvider::Initialize(target);
 	FixInitiator::Initialize(target);
 	FixAcceptor::Initialize(target);
+  FixSession::Initialize();
 }
 
 // Register the module with node.


### PR DESCRIPTION
Here is a solution to memory leaks that occur within `getSession` method of both `FixInitiator` and `FixAcceptor`.
The solution is based on

1. Establishing a constructor for `FixSession` just once by calling `Initialize` of `FixSession`. `Initialize` will not install itself in the `target`, but will (Re)set the internal global Persistent `g_Ctor` handle.
2. `wrapFixSession` now follows the known `NewInstance` pattern, and makes use of `Nan::EscapableHandleScope`.

Additional noise in the PR comes from indentation.