### PR TITLE
amended FixAcceptor.cpp to make username (tag 553) optional

### DIFF
--- a/src/FixApplication.cpp
+++ b/src/FixApplication.cpp
@@ -42,7 +42,9 @@ void FixApplication::onLogout( const FIX::SessionID& sessionID )
 void FixApplication::toAdmin( FIX::Message& message, const FIX::SessionID& sessionID )
 {
 	if(strcmp(message.getHeader().getField(35).c_str(), "A") == 0 && mCredentials != NULL) {
-		message.setField(553, mCredentials->username.c_str());
+		if (strcmp(mCredentials->username.c_str(), "") != 0) {
+			message.setField(553, mCredentials->username.c_str());
+		}
 		message.setField(554, mCredentials->password.c_str());
 	}
 


### PR DESCRIPTION
One of our LPs requires a password but no username (so tag 553 needs to be omitted even though tag 554 is required); this change allows that to happen if the username in the config credentials is set to a zero length string.
